### PR TITLE
iOS Deployment Target 11.0

### DIFF
--- a/NotAutoLayout.xcodeproj/project.pbxproj
+++ b/NotAutoLayout.xcodeproj/project.pbxproj
@@ -232,7 +232,7 @@
 
 /* Begin PBXFileReference section */
 		"NotAutoLayout::NotAutoLayout::Product" /* NotAutoLayout.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NotAutoLayout.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"NotAutoLayout::NotAutoLayoutTests::Product" /* NotAutoLayoutTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = NotAutoLayoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"NotAutoLayout::NotAutoLayoutTests::Product" /* NotAutoLayoutTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = NotAutoLayoutTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		OBJ_100 /* LeftCenterTop.Individual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftCenterTop.Individual.swift; sourceTree = "<group>"; };
 		OBJ_101 /* LeftMiddleBottom.Individual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeftMiddleBottom.Individual.swift; sourceTree = "<group>"; };
@@ -1196,7 +1196,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = NotAutoLayout.xcodeproj/NotAutoLayout_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -1222,7 +1222,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = NotAutoLayout.xcodeproj/NotAutoLayout_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -1328,7 +1328,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = NotAutoLayout.xcodeproj/NotAutoLayoutTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -1353,7 +1353,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = NotAutoLayout.xcodeproj/NotAutoLayoutTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "NotAutoLayout",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v11),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/Sources/NotAutoLayout/Extensions/UIView.swift
+++ b/Sources/NotAutoLayout/Extensions/UIView.swift
@@ -36,7 +36,6 @@ extension UIView {
 		return Rect(frame)
 	}
 	
-	@available(iOS 11.0, *)
 	var safeAreaRect: Rect {
 		let insets = Insets(self.safeAreaInsets)
 		return self.boundsRect.rect(inside: insets)
@@ -93,7 +92,6 @@ extension UIView {
 		
 	}
 	
-	@available(iOS 11.0, *)
 	func safeAreaFrame(in targetView: UIView?) -> Rect {
 		
 		let insets = Insets(self.safeAreaInsets)

--- a/Sources/NotAutoLayout/Layout/LayoutElement.swift
+++ b/Sources/NotAutoLayout/Layout/LayoutElement.swift
@@ -52,11 +52,7 @@ extension LayoutElement {
 			
 			case fit(Float?, layoutGuideGetter: (ViewLayoutGuides) -> LayoutGuideRepresentable)
 			case fill(Float?, layoutGuideGetter: (ViewLayoutGuides) -> LayoutGuideRepresentable)
-			
-			@available(iOS 11.0, *)
 			case safeAreaFit(Float?, safeAreaOnly: Bool)
-			
-			@available(iOS 11.0, *)
 			case safeAreaFill(Float?, safeAreaOnly: Bool)
 			
 			var ratio: Float? {

--- a/Sources/NotAutoLayout/Layout/ViewLayoutGuides.swift
+++ b/Sources/NotAutoLayout/Layout/ViewLayoutGuides.swift
@@ -186,7 +186,6 @@ extension ViewLayoutGuides {
 		return self.makeGuide(direction: self.parentView?.currentDirection, rect: self.parentView?.readableRect)
 	}
 	
-	@available(iOS 11.0, *)
 	public var safeAreaGuide: Guide {
 		return self.makeGuide(direction: self.parentView?.currentDirection, rect: self.parentView?.safeAreaRect)
 	}
@@ -239,7 +238,6 @@ extension ViewLayoutGuides {
 		return (self.parentView?.layoutMargins).map({ Insets($0) }) ?? .zero
 	}
 	
-	@available(iOS 11.0, *)
 	public var safeAreaInsets: Insets {
 		return (self.parentView?.safeAreaInsets).map({ Insets($0) }) ?? .zero
 	}

--- a/Sources/NotAutoLayout/Layout/ViewPinGuides.swift
+++ b/Sources/NotAutoLayout/Layout/ViewPinGuides.swift
@@ -112,7 +112,6 @@ extension ViewPinGuides.Horizontal {
 							  rect: self.referenceView?.readableFrame(in: self.parentView))
 	}
 	
-	@available(iOS 11.0, *)
 	public var safeAreaGuide: Guide {
 		return self.makeGuide(directionGetter: { [weak referenceView] in referenceView?.currentDirection },
 							  rect: self.referenceView?.safeAreaFrame(in: self.parentView))
@@ -199,7 +198,6 @@ extension ViewPinGuides.Vertical {
 		return self.makeGuide(rect: self.referenceView?.readableFrame(in: self.parentView))
 	}
 	
-	@available(iOS 11.0, *)
 	public var safeAreaGuide: Guide {
 		return self.makeGuide(rect: self.referenceView?.safeAreaFrame(in: self.parentView))
 	}
@@ -277,7 +275,6 @@ extension ViewPinGuides.Point {
 							  rect: self.referenceView?.readableFrame(in: self.parentView))
 	}
 	
-	@available(iOS 11.0, *)
 	public var safeAreaGuide: Guide {
 		return self.makeGuide(directionGetter: { [weak referenceView] in referenceView?.currentDirection },
 							  rect: self.referenceView?.safeAreaFrame(in: self.parentView))

--- a/Sources/NotAutoLayout/LayoutMaker/MakerBasics/LayoutPropertyCanStoreFrameType.swift
+++ b/Sources/NotAutoLayout/LayoutMaker/MakerBasics/LayoutPropertyCanStoreFrameType.swift
@@ -62,7 +62,6 @@ extension LayoutMaker where Property: LayoutPropertyCanStoreFrameType {
 		
 	}
 	
-	@available(iOS 11.0, *)
 	public func stickOnParentSafeArea(withInsets insets: Insets = .zero) -> LayoutMaker<Property.WillSetFrameProperty> {
 		
 		let frame = LayoutElement.Rect.byParent({ $0.safeAreaGuide.frame(inside: insets) })

--- a/Sources/NotAutoLayout/LayoutMaker/MakerBasics/LayoutPropertyCanStoreSizeType.swift
+++ b/Sources/NotAutoLayout/LayoutMaker/MakerBasics/LayoutPropertyCanStoreSizeType.swift
@@ -76,7 +76,6 @@ extension LayoutMaker where Property: LayoutPropertyCanStoreSizeType {
 		
 	}
 	
-	@available(iOS 11.0, *)
 	public func aspectFit(ratio: Float? = nil, safeAreaOnly shouldOnlyIncludeSafeArea: Bool) -> LayoutMaker<Property.WillSetSizeProperty> {
 		
 		let size = LayoutElement.Size.aspect(.safeAreaFit(ratio, safeAreaOnly: shouldOnlyIncludeSafeArea))
@@ -86,7 +85,6 @@ extension LayoutMaker where Property: LayoutPropertyCanStoreSizeType {
 		
 	}
 	
-	@available(iOS 11.0, *)
 	public func aspectFill(ratio: Float? = nil, safeAreaOnly shouldOnlyIncludeSafeArea: Bool) -> LayoutMaker<Property.WillSetSizeProperty> {
 		
 		let size = LayoutElement.Size.aspect(.safeAreaFill(ratio, safeAreaOnly: shouldOnlyIncludeSafeArea))

--- a/Tests/NotAutoLayoutTests/LayoutTest/ViewLayoutGuidesTest.swift
+++ b/Tests/NotAutoLayoutTests/LayoutTest/ViewLayoutGuidesTest.swift
@@ -128,7 +128,6 @@ class ViewLayoutGuidesTest: XCTestCase {
 		
 	}
 	
-	@available(iOS 11.0, *)
 	func testSafeAreaGuide() {
 		
 		// TODO: Find a way to add the view controller to the view hierarchy, otherwise the views cannot get the correct safe area settings.


### PR DESCRIPTION
Drop iOS 9.0 and 10.0

Build failed on Xcode13 Beta
Enum cases with associated values cannot be marked potentially unavailable with '@available'

Developer Forumns
https://developer.apple.com/forums/thread/682351

fixes #1